### PR TITLE
Allowing JQuery to be updated beyond 3.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,7 +48,7 @@
   ],
   "devDependencies": {},
   "dependencies": {
-    "jquery": ">=1.9.0 <3.2",
+    "jquery": ">=1.9.0",
     "jquery.documentsize": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "reinstall": "npm run cleanup -s && npm run setup || npm run setup"
   },
   "dependencies": {
-    "jquery": ">=1.9.0 <3.2",
+    "jquery": ">=1.9.0",
     "jquery.documentsize": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
A security issue was found within jQuery.extend (versions <= 3.3 see https://www.cvedetails.com/cve/CVE-2019-11358/). Because the package.json locked versions lower than 3.2 I was unable to patch the security issue within my other project. The following PR removes that restraint. 

Tests came up as green when running with jQuery at version 3.4.1. 